### PR TITLE
Add less strict return to URL matching to Pascal

### DIFF
--- a/Source/Pascal/.docker/config.yaml
+++ b/Source/Pascal/.docker/config.yaml
@@ -12,6 +12,7 @@ urls:
     default: http://localhost:80/return
     allowed:
       - http://localhost:80/return
+    mode: strict
 
 sessions:
   nonce_length: 80

--- a/Source/Pascal/configuration/viper/initiation.go
+++ b/Source/Pascal/configuration/viper/initiation.go
@@ -3,6 +3,7 @@ package viper
 import (
 	"net/url"
 
+	"dolittle.io/pascal/initiation"
 	"github.com/spf13/viper"
 )
 
@@ -10,8 +11,10 @@ const (
 	urlsReturnQueryParameterKey = "urls.return.query_parameter"
 	urlsReturnDefaultKey        = "urls.return.default"
 	urlsReturnAllowedKey        = "urls.return.allowed"
+	urlsReturnModeKey           = "urls.return.mode"
 
 	defaultReturnToParameter = "return_to"
+	defaultReturnMode        = initiation.MatchModeStrict
 )
 
 var (
@@ -53,4 +56,13 @@ func (c *initiationConfiguration) AllowedReturnTo() []*url.URL {
 	}
 
 	return allowed
+}
+
+func (c *initiationConfiguration) ReturnToMatchMode() initiation.MatchMode {
+	switch viper.GetString(urlsReturnModeKey) {
+	case "prefix":
+		return initiation.MatchModePrefix
+	default:
+		return defaultReturnMode
+	}
 }

--- a/Source/Pascal/initiation/configuration.go
+++ b/Source/Pascal/initiation/configuration.go
@@ -2,8 +2,16 @@ package initiation
 
 import "net/url"
 
+type MatchMode int
+
+const (
+	MatchModeStrict MatchMode = iota
+	MatchModePrefix
+)
+
 type Configuration interface {
 	ReturnToParameter() string
 	DefaultReturnTo() *url.URL
 	AllowedReturnTo() []*url.URL
+	ReturnToMatchMode() MatchMode
 }


### PR DESCRIPTION
The matching of allowed Return To URLs can be configured to either be "strict" (default) or "prefix".

The strict mode matches the entire url (scheme + host + path) exactly, while the prefix mode matches the scheme + host exactly, and checks if the allowed path is a prefix of the requested path.