### PR TITLE
Add support for fetching ID tokens - and special case support for Azure B2C as a provider.

### DIFF
--- a/Source/Pascal/.docker/config.yaml
+++ b/Source/Pascal/.docker/config.yaml
@@ -33,6 +33,7 @@ openid:
     secret: client-secret
   scopes:
     - openid
+  token_type: access_token
   redirect: http://localhost:80/callback
 
 cookies:

--- a/Source/Pascal/completion/completer.go
+++ b/Source/Pascal/completion/completer.go
@@ -2,13 +2,13 @@ package completion
 
 import (
 	"dolittle.io/pascal/openid"
+	"dolittle.io/pascal/openid/issuer"
 	"dolittle.io/pascal/sessions"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 )
 
 type Completer interface {
-	Complete(response *Response, session *sessions.Session) (*oauth2.Token, error)
+	Complete(response *Response, session *sessions.Session) (*issuer.Token, error)
 }
 
 func NewCompleter(validator Validator, exchanger openid.TokenExchanger, logger *zap.Logger) Completer {
@@ -25,7 +25,7 @@ type completer struct {
 	logger    *zap.Logger
 }
 
-func (c *completer) Complete(response *Response, session *sessions.Session) (*oauth2.Token, error) {
+func (c *completer) Complete(response *Response, session *sessions.Session) (*issuer.Token, error) {
 	if sesionIsValid, err := c.validator.Validate(response, session); !sesionIsValid {
 		c.logger.Error("session was not valid", zap.Error(err))
 		return nil, ErrSessionDoesNotMatchProviderCallback

--- a/Source/Pascal/configuration/viper/openid.go
+++ b/Source/Pascal/configuration/viper/openid.go
@@ -3,6 +3,7 @@ package viper
 import (
 	"net/url"
 
+	"dolittle.io/pascal/openid/config"
 	"github.com/spf13/viper"
 )
 
@@ -11,6 +12,7 @@ const (
 	openidClientIDKey     = "openid.client.id"
 	openidClientSecretKey = "openid.client.secret"
 	openidScopesKey       = "openid.scopes"
+	openidTokenTypeKey    = "openid.token_type"
 	openidRedirectURLKey  = "openid.redirect"
 )
 
@@ -31,6 +33,10 @@ func (c *openidConfiguration) ClientSecret() string {
 
 func (c *openidConfiguration) Scopes() []string {
 	return viper.GetStringSlice(openidScopesKey)
+}
+
+func (c *openidConfiguration) TokenType() config.TokenType {
+	return config.TokenType(viper.GetString(openidTokenTypeKey))
 }
 
 func (c *openidConfiguration) RedirectURL() *url.URL {

--- a/Source/Pascal/cookies/writer.go
+++ b/Source/Pascal/cookies/writer.go
@@ -3,11 +3,11 @@ package cookies
 import (
 	"net/http"
 
-	"golang.org/x/oauth2"
+	"dolittle.io/pascal/openid/issuer"
 )
 
 type Writer interface {
-	WriteTokenCookie(token *oauth2.Token, w http.ResponseWriter) error
+	WriteTokenCookie(token *issuer.Token, w http.ResponseWriter) error
 }
 
 func NewWriter(configuration Configuration) Writer {
@@ -20,11 +20,11 @@ type writer struct {
 	configuration Configuration
 }
 
-func (w *writer) WriteTokenCookie(token *oauth2.Token, responseWriter http.ResponseWriter) error {
+func (w *writer) WriteTokenCookie(token *issuer.Token, responseWriter http.ResponseWriter) error {
 	cookie := http.Cookie{
 		Name:     w.configuration.Name(),
-		Value:    token.AccessToken,
-		Expires:  token.Expiry,
+		Value:    token.Value,
+		Expires:  token.Expires,
 		HttpOnly: true,
 		Secure:   w.configuration.Secure(),
 		SameSite: w.configuration.SameSite(),

--- a/Source/Pascal/openid/authentication_initiator.go
+++ b/Source/Pascal/openid/authentication_initiator.go
@@ -28,9 +28,13 @@ type initiator struct {
 }
 
 func (i *initiator) GetAuthenticationRedirect(nonce nonces.Nonce) (AuthenticationRedirectURL, error) {
-	config, err := i.watcher.GetConfig()
+	issuer, err := i.watcher.GetIssuer()
 	if err != nil {
 		return "", err
 	}
-	return AuthenticationRedirectURL(config.AuthCodeURL(string(nonce))), nil
+	redirect, err := issuer.GetAuthenticationRedirectURL(nonce)
+	if err != nil {
+		return "", err
+	}
+	return AuthenticationRedirectURL(redirect), nil
 }

--- a/Source/Pascal/openid/config/configuration.go
+++ b/Source/Pascal/openid/config/configuration.go
@@ -2,10 +2,18 @@ package config
 
 import "net/url"
 
+type TokenType string
+
+const (
+	AccessToken TokenType = "access_token"
+	IDToken     TokenType = "id_token"
+)
+
 type Configuration interface {
 	Issuer() *url.URL
 	ClientID() string
 	ClientSecret() string
 	Scopes() []string
+	TokenType() TokenType
 	RedirectURL() *url.URL
 }

--- a/Source/Pascal/openid/config/httpclient.go
+++ b/Source/Pascal/openid/config/httpclient.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func getHttpClientFor(issuer *url.URL, query url.Values) *http.Client {
+	return &http.Client{
+		Transport: &roundTripperWithWellKnownRequestQuery{
+			issuer: issuer,
+			query:  query,
+		},
+	}
+}
+
+type roundTripperWithWellKnownRequestQuery struct {
+	issuer *url.URL
+	query  url.Values
+}
+
+func (r *roundTripperWithWellKnownRequestQuery) RoundTrip(request *http.Request) (*http.Response, error) {
+	wellKnownEndpoint := strings.TrimSuffix(r.issuer.String(), "/") + "/.well-known/openid-configuration"
+
+	if request.URL.String() == wellKnownEndpoint {
+		request.URL.RawQuery = r.query.Encode()
+	}
+
+	return http.DefaultTransport.RoundTrip(request)
+}

--- a/Source/Pascal/openid/issuer/errors.go
+++ b/Source/Pascal/openid/issuer/errors.go
@@ -1,0 +1,7 @@
+package issuer
+
+import "errors"
+
+var (
+	ErrIDTokenMissing = errors.New("ID token not received in token from issuer")
+)

--- a/Source/Pascal/openid/issuer/httpclient.go
+++ b/Source/Pascal/openid/issuer/httpclient.go
@@ -1,4 +1,4 @@
-package config
+package issuer
 
 import (
 	"net/http"

--- a/Source/Pascal/openid/issuer/issuer.go
+++ b/Source/Pascal/openid/issuer/issuer.go
@@ -1,0 +1,119 @@
+package issuer
+
+import (
+	"context"
+	"net/url"
+
+	"dolittle.io/pascal/sessions/nonces"
+	"github.com/coreos/go-oidc"
+	"golang.org/x/oauth2"
+)
+
+const idTokenKey = "id_token"
+
+type Issuer interface {
+	GetAuthenticationRedirectURL(nonce nonces.Nonce) (string, error)
+	ExchangeCodeForAccessToken(code string) (*Token, error)
+	ExchangeCodeForIDToken(code string) (*Token, error)
+}
+
+type issuer struct {
+	provider *oidc.Provider
+	verifier *oidc.IDTokenVerifier
+	config   *oauth2.Config
+}
+
+func NewIssuer(issuerURL *url.URL, clientId, clientSecret string, scopes []string, redirectUrl *url.URL) (Issuer, error) {
+	issuerUrl, query := splitIssuerUrlAndQuery(issuerURL)
+
+	ctx := context.Background()
+	if len(query) > 0 {
+		client := getHttpClientFor(issuerUrl, query)
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
+	}
+
+	provider, err := oidc.NewProvider(ctx, issuerUrl.String())
+	if err != nil {
+		return nil, err
+	}
+
+	config := &oauth2.Config{
+		ClientID:     clientId,
+		ClientSecret: clientSecret,
+		Endpoint:     provider.Endpoint(),
+		Scopes:       getScopesWithOpenID(scopes),
+		RedirectURL:  redirectUrl.String(),
+	}
+
+	verifier := provider.Verifier(&oidc.Config{
+		ClientID: clientId,
+	})
+
+	return &issuer{
+		provider: provider,
+		verifier: verifier,
+		config:   config,
+	}, nil
+}
+
+func (i *issuer) GetAuthenticationRedirectURL(nonce nonces.Nonce) (string, error) {
+	return i.config.AuthCodeURL(string(nonce)), nil
+}
+
+func (i *issuer) ExchangeCodeForAccessToken(code string) (*Token, error) {
+	token, err := i.config.Exchange(context.Background(), code)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Token{
+		Value:   token.AccessToken,
+		Expires: token.Expiry,
+	}, nil
+}
+
+func (i *issuer) ExchangeCodeForIDToken(code string) (*Token, error) {
+	token, err := i.config.Exchange(context.Background(), code)
+	if err != nil {
+		return nil, err
+	}
+
+	idTokenValue, ok := token.Extra(idTokenKey).(string)
+	if !ok {
+		return nil, ErrIDTokenMissing
+	}
+
+	idToken, err := i.verifier.Verify(context.Background(), idTokenValue)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Token{
+		Value:   idTokenValue,
+		Expires: idToken.Expiry,
+	}, nil
+}
+
+func splitIssuerUrlAndQuery(issuerUrl *url.URL) (*url.URL, url.Values) {
+	if len(issuerUrl.Query()) > 0 {
+		return &url.URL{
+			Scheme:  issuerUrl.Scheme,
+			Opaque:  issuerUrl.Opaque,
+			User:    issuerUrl.User,
+			Host:    issuerUrl.Host,
+			Path:    issuerUrl.Path,
+			RawPath: issuerUrl.RawPath,
+		}, issuerUrl.Query()
+	} else {
+		return issuerUrl, nil
+	}
+}
+
+func getScopesWithOpenID(scopes []string) []string {
+	for _, scope := range scopes {
+		if scope == oidc.ScopeOpenID {
+			return scopes
+		}
+	}
+	return append(scopes, oidc.ScopeOpenID)
+}

--- a/Source/Pascal/openid/issuer/token.go
+++ b/Source/Pascal/openid/issuer/token.go
@@ -1,0 +1,8 @@
+package issuer
+
+import "time"
+
+type Token struct {
+	Value   string
+	Expires time.Time
+}

--- a/Source/Pascal/openid/token_exchanger.go
+++ b/Source/Pascal/openid/token_exchanger.go
@@ -1,18 +1,16 @@
 package openid
 
 import (
-	"context"
-
 	"dolittle.io/pascal/configuration/changes"
 	"dolittle.io/pascal/openid/config"
+	"dolittle.io/pascal/openid/issuer"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 )
 
 type AuthenticationCode string
 
 type TokenExchanger interface {
-	Exchange(code AuthenticationCode) (*oauth2.Token, error)
+	Exchange(code AuthenticationCode) (*issuer.Token, error)
 }
 
 func NewTokenExchanger(configuration config.Configuration, notifier changes.ConfigurationChangeNotifier, logger *zap.Logger) (TokenExchanger, error) {
@@ -21,18 +19,33 @@ func NewTokenExchanger(configuration config.Configuration, notifier changes.Conf
 		return nil, err
 	}
 	return &exchanger{
-		watcher: watcher,
+		configuration: configuration,
+		watcher:       watcher,
+		logger:        logger,
 	}, nil
 }
 
 type exchanger struct {
-	watcher config.Watcher
+	configuration config.Configuration
+	watcher       config.Watcher
+	logger        *zap.Logger
 }
 
-func (e *exchanger) Exchange(code AuthenticationCode) (*oauth2.Token, error) {
-	config, err := e.watcher.GetConfig()
+func (e *exchanger) Exchange(code AuthenticationCode) (*issuer.Token, error) {
+	issuer, err := e.watcher.GetIssuer()
 	if err != nil {
 		return nil, err
 	}
-	return config.Exchange(context.Background(), string(code))
+
+	switch e.configuration.TokenType() {
+	case config.IDToken:
+		e.logger.Debug("Exchanging code for id token")
+		return issuer.ExchangeCodeForIDToken(string(code))
+	case config.AccessToken:
+		e.logger.Debug("Exchanging code for access token")
+		return issuer.ExchangeCodeForAccessToken(string(code))
+	default:
+		e.logger.Warn("Invalid token type configured, falling back to access token", zap.String("token_type", string(e.configuration.TokenType())))
+		return issuer.ExchangeCodeForAccessToken(string(code))
+	}
 }


### PR DESCRIPTION
## Summary

This PR adds support for using ID tokens as the value to store in the cookie. It introduces a configuration variable in `openid.token_type` that can be either `access_token` or `id_token` (defaults to `access_token` with a warning if not specified. 

Also, it seems like Azure B2C has a slightly non-standard way of acting as an OpenID Connect issuer - the well-known document requires a _flow_ query-parameter set for it to work. To support this - any query parameters set in the `openid.issuer` configuration - will be stripped away when passed to the underlying `go-oidc` library - but then added back at the end while resolving the well-known discovery document.

### Added

- Ability to use ID tokens as values in cookies. NOTE: the issuer still has to return an `access_token` in the response from the Token-endpoint for it to work.

### Fixed

- Special case handling of query-parameters in the configured issuer URL to support Azure B2C.
