### PR TITLE
Fix bug where logging out when not logged in causes an error

### DIFF
--- a/Deployment/Development/users/login.yaml
+++ b/Deployment/Development/users/login.yaml
@@ -14,6 +14,7 @@ frontend:
 
 urls:
   error: https://studio.localhost:8080/.auth/error
+  logged_out: https://studio.localhost:8080/.auth/logged-out
 
 
 providers:

--- a/Source/Login/.docker/config.yaml
+++ b/Source/Login/.docker/config.yaml
@@ -10,7 +10,8 @@ frontend:
     logout: /.auth/cookies/logout
 
 urls:
-  error: http://localhost:8080/error
+  error: http://localhost:8080/.auth/error
+  logged_out: http://localhost:8080/.auth/logged-out
 
 providers: {}
 

--- a/Source/Login/Backend/clients/kratos/client.go
+++ b/Source/Login/Backend/clients/kratos/client.go
@@ -63,7 +63,10 @@ func (c *client) GetLogoutURL(ctx context.Context, cookies []*http.Cookie) (*ory
 		}
 	}
 	cookieHeaderValue := strings.Join(cookieStrings, ";")
-	url, _, err := c.api.CreateSelfServiceLogoutFlowUrlForBrowsers(ctx).Cookie(cookieHeaderValue).Execute()
+	url, response, err := c.api.CreateSelfServiceLogoutFlowUrlForBrowsers(ctx).Cookie(cookieHeaderValue).Execute()
+	if response.StatusCode == http.StatusUnauthorized {
+		return nil, ErrKratosUnauthorized
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/Source/Login/Backend/configuration/container.go
+++ b/Source/Login/Backend/configuration/container.go
@@ -148,6 +148,7 @@ func NewContainer(configuration Configuration) (*Container, error) {
 		container.HydraClient)
 
 	container.LogoutFlowInitiator = logoutFlow.NewInitiator(
+		configuration.Flows().Logout(),
 		container.KratosClient)
 
 	frontendHandler, err := public.NewFrontendHandler(

--- a/Source/Login/Backend/configuration/viper/flows/logout.go
+++ b/Source/Login/Backend/configuration/viper/flows/logout.go
@@ -1,11 +1,23 @@
 package flows
 
-import "github.com/spf13/viper"
+import (
+	"github.com/spf13/viper"
+	"net/url"
+)
 
 const (
 	logoutFlowIDQueryParameterKey = "flows.logout.flow_id_query_parameter"
+	urlsLoggedOutKey              = "urls.logged_out"
 
 	defaultLogoutFlowIDQueryParameter = "logout_challenge"
+)
+
+var (
+	defaultLoggedOutRedirect = &url.URL{
+		Scheme: "http",
+		Host:   "localhost:8080",
+		Path:   "error",
+	}
 )
 
 type Logout struct{}
@@ -15,4 +27,16 @@ func (l *Logout) FlowIDQueryParameter() string {
 		return value
 	}
 	return defaultLogoutFlowIDQueryParameter
+}
+
+func (l *Logout) LoggedOutRedirect() *url.URL {
+	value := viper.GetString(urlsLoggedOutKey)
+	if value == "" {
+		return defaultLoggedOutRedirect
+	}
+	url, err := url.Parse(value)
+	if err != nil {
+		return defaultLoggedOutRedirect
+	}
+	return url
 }

--- a/Source/Login/Backend/flows/logout/configuration.go
+++ b/Source/Login/Backend/flows/logout/configuration.go
@@ -1,5 +1,8 @@
 package logout
 
+import "net/url"
+
 type Configuration interface {
 	FlowIDQueryParameter() string
+	LoggedOutRedirect() *url.URL
 }


### PR DESCRIPTION
## Summary

Fixes a problem where it would not be possible to get out of some error states. The issue was that the error page asks you to log out and try again, but if the user is not logged in - the logout flow would fail and send you back to the error page. Thus creating an infinite loop.

### Added

- [Login/Backend] Configuration for redirect URL when logging out and there is no logged in user.

### Fixed

- [Login/Backend] If there is no session in Kratos (initiate logout flow returns 401), redirect to the configured logged-out URL.