### PR TITLE
[Pascal]: Add support for multi-host setups

### DIFF
--- a/Source/Login/Web/package.json
+++ b/Source/Login/Web/package.json
@@ -15,13 +15,13 @@
         "@emotion/styled": "11.10.0",
         "@mui/icons-material": "5.10.2",
         "@mui/material": "5.10.2",
-        "@rest-hooks/endpoint": "2.2.12",
-        "@rest-hooks/hooks": "3.0.3",
-        "@rest-hooks/rest": "5.0.6",
+        "@rest-hooks/endpoint": "2.3.1",
+        "@rest-hooks/hooks": "3.0.7",
+        "@rest-hooks/rest": "5.2.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-router-dom": "6.3.0",
-        "rest-hooks": "6.3.9"
+        "rest-hooks": "6.4.1"
     },
     "devDependencies": {
         "@babel/core": "7.18.13",

--- a/Source/Pascal/.docker/config.yaml
+++ b/Source/Pascal/.docker/config.yaml
@@ -1,20 +1,23 @@
 serve:
   port: 80
 
+  hosts:
+    - localhost:80
+
   paths:
     initiate: /initiate
     complete: /callback
     logout: /logout
 
 urls:
-  error: http://localhost:80/error
+  error: /error
   return:
     query_parameter: return_to
     default:
-      login: http://localhost:80/return
-      logout: http://localhost:80/return
+      login: /return
+      logout: /return
     allowed:
-      - http://localhost:80/return
+      - /
     mode: strict
 
 sessions:
@@ -37,7 +40,7 @@ openid:
   scopes:
     - openid
   token_type: access_token
-  redirect: http://localhost:80/callback
+  redirect: /callback
 
 cookies:
   name: .dolittle.pascal.login

--- a/Source/Pascal/configuration/container.go
+++ b/Source/Pascal/configuration/container.go
@@ -50,7 +50,7 @@ type Container struct {
 }
 
 func NewContainer(config Configuration) (*Container, error) {
-	logger, _ := zap.NewDevelopment()
+	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 	container := Container{}
 
 	container.Notifier = changes.NewConfigurationChangeNotifier(logger)

--- a/Source/Pascal/configuration/viper/redirects.go
+++ b/Source/Pascal/configuration/viper/redirects.go
@@ -2,8 +2,6 @@ package viper
 
 import (
 	"dolittle.io/pascal/redirects"
-	"net/url"
-
 	"github.com/spf13/viper"
 )
 
@@ -15,20 +13,9 @@ const (
 	urlsReturnModeKey           = "urls.return.mode"
 
 	defaultReturnToParameter = "return_to"
+	defaultLoginReturnTo     = "return"
+	defaultLogoutReturnTo    = "return"
 	defaultReturnMode        = redirects.MatchModeStrict
-)
-
-var (
-	defaultLoginReturnTo = &url.URL{
-		Scheme: "http",
-		Host:   "localhost:8080",
-		Path:   "return",
-	}
-	defaultLogoutReturnTo = &url.URL{
-		Scheme: "http",
-		Host:   "localhost:8080",
-		Path:   "return",
-	}
 )
 
 type redirectsConfiguration struct{}
@@ -40,40 +27,28 @@ func (c *redirectsConfiguration) ReturnToParameter() string {
 	return defaultReturnToParameter
 }
 
-func (c *redirectsConfiguration) DefaultLoginReturnTo() *url.URL {
-	value := viper.GetString(urlsLoginReturnDefaultKey)
-	if value == "" {
-		return defaultLoginReturnTo
+func (c *redirectsConfiguration) DefaultLoginReturnTo() string {
+	if value := viper.GetString(urlsLoginReturnDefaultKey); value != "" {
+		return value
 	}
-	url, err := url.Parse(value)
-	if err != nil {
-		return defaultLoginReturnTo
-	}
-	return url
+	return defaultLoginReturnTo
 }
 
-func (c *redirectsConfiguration) DefaultLogoutReturnTo() *url.URL {
-	value := viper.GetString(urlsLogoutReturnDefaultKey)
-	if value == "" {
-		return defaultLogoutReturnTo
+func (c *redirectsConfiguration) DefaultLogoutReturnTo() string {
+	if value := viper.GetString(urlsLogoutReturnDefaultKey); value != "" {
+		return value
 	}
-	url, err := url.Parse(value)
-	if err != nil {
-		return defaultLogoutReturnTo
-	}
-	return url
+	return defaultLogoutReturnTo
 }
 
-func (c *redirectsConfiguration) AllowedReturnTo() []*url.URL {
-	allowed := []*url.URL{
+func (c *redirectsConfiguration) AllowedReturnTo() []string {
+	allowed := []string{
 		c.DefaultLoginReturnTo(),
 		c.DefaultLogoutReturnTo(),
 	}
 
 	for _, value := range viper.GetStringSlice(urlsReturnAllowedKey) {
-		if url, err := url.Parse(value); err != nil {
-			allowed = append(allowed, url)
-		}
+		allowed = append(allowed, value)
 	}
 
 	return allowed

--- a/Source/Pascal/configuration/viper/server.go
+++ b/Source/Pascal/configuration/viper/server.go
@@ -1,13 +1,12 @@
 package viper
 
 import (
-	"net/url"
-
 	"github.com/spf13/viper"
 )
 
 const (
 	servePortKey          = "serve.port"
+	serveHostsKey         = "serve.hosts"
 	servePathsInitiateKey = "serve.paths.initiate"
 	servePathsCompleteKey = "serve.paths.complete"
 	servePathsLogoutKey   = "serve.paths.logout"
@@ -17,14 +16,11 @@ const (
 	defaultServeInitiatePath = "/initiate"
 	defaultServeCompletePath = "/callback"
 	defaultServeLogoutPath   = "/logout"
+	defaultErrorRedirect     = "/error"
 )
 
 var (
-	defaultErrorRedirect = &url.URL{
-		Scheme: "http",
-		Host:   "localhost:8080",
-		Path:   "error",
-	}
+	defaultHosts = []string{"localhost:8080"}
 )
 
 type serverConfiguration struct{}
@@ -35,6 +31,14 @@ func (c *serverConfiguration) Port() int {
 		return defaultServePort
 	}
 	return port
+}
+
+func (c *serverConfiguration) AllowedHosts() []string {
+	if hosts := viper.GetStringSlice(serveHostsKey); len(hosts) > 0 {
+		return hosts
+	}
+
+	return defaultHosts
 }
 
 func (c *serverConfiguration) InitiatePath() string {
@@ -58,14 +62,9 @@ func (c *serverConfiguration) LogoutPath() string {
 	return defaultServeLogoutPath
 }
 
-func (c *serverConfiguration) ErrorRedirect() *url.URL {
-	value := viper.GetString(urlsErrorKey)
-	if value == "" {
-		return defaultErrorRedirect
+func (c *serverConfiguration) ErrorRedirect() string {
+	if value := viper.GetString(urlsErrorKey); value != "" {
+		return value
 	}
-	url, err := url.Parse(value)
-	if err != nil {
-		return defaultErrorRedirect
-	}
-	return url
+	return defaultErrorRedirect
 }

--- a/Source/Pascal/initiation/initiator.go
+++ b/Source/Pascal/initiation/initiator.go
@@ -36,7 +36,7 @@ func (i *initiator) Initiate(request *Request) (*sessions.Session, openid.Authen
 		return nil, "", err
 	}
 
-	redirect, err := i.initiator.GetAuthenticationRedirect(session.Nonce)
+	redirect, err := i.initiator.GetAuthenticationRedirect(request.Host, session.Nonce)
 	if err != nil {
 		return nil, "", err
 	}

--- a/Source/Pascal/initiation/parser.go
+++ b/Source/Pascal/initiation/parser.go
@@ -23,12 +23,18 @@ type parser struct {
 }
 
 func (p *parser) ParseFrom(r *http.Request) (*Request, error) {
-	returnTo, err := redirects.GetReturnToURL(p.configuration, p.configuration.DefaultLoginReturnTo(), r, p.logger)
+	defaultReturnTo, err := redirects.GetAbsoluteUrlFor(r, p.configuration.DefaultLoginReturnTo())
+	if err != nil {
+		return nil, err
+	}
+
+	returnTo, err := redirects.GetReturnToURL(p.configuration, defaultReturnTo, r, p.logger)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Request{
+		Host:     redirects.GetHostFor(r),
 		ReturnTo: returnTo,
 	}, nil
 }

--- a/Source/Pascal/initiation/request.go
+++ b/Source/Pascal/initiation/request.go
@@ -3,5 +3,6 @@ package initiation
 import "dolittle.io/pascal/sessions"
 
 type Request struct {
+	Host     string
 	ReturnTo sessions.ReturnToURL
 }

--- a/Source/Pascal/initiation/validator.go
+++ b/Source/Pascal/initiation/validator.go
@@ -26,7 +26,7 @@ type validator struct {
 }
 
 func (v *validator) Validate(r *Request) (bool, error) {
-	if !v.returnToURLIsAllowed(r.ReturnTo) {
+	if !v.returnToURLIsAllowed(r.ReturnTo, r.Host) {
 		returnTo := url.URL(*r.ReturnTo)
 		v.logger.Warn("the requested return to URL is not allowed", zap.String("requested", returnTo.String()))
 		return false, redirects.ErrRequestedReturnToIsNotAllowed
@@ -35,26 +35,27 @@ func (v *validator) Validate(r *Request) (bool, error) {
 	return true, nil
 }
 
-func (v *validator) returnToURLIsAllowed(requested sessions.ReturnToURL) bool {
-	for _, allowed := range v.configuration.AllowedReturnTo() {
-		if urlEqualsSchemeHostPath(requested, allowed, v.configuration.ReturnToMatchMode()) {
+func (v *validator) returnToURLIsAllowed(requested sessions.ReturnToURL, allowedHost string) bool {
+	for _, allowedPath := range v.configuration.AllowedReturnTo() {
+		if urlEqualsSchemeHostPath(requested, allowedHost, allowedPath, v.configuration.ReturnToMatchMode()) {
 			return true
 		}
 	}
 	return false
 }
 
-func urlEqualsSchemeHostPath(requested, allowed *url.URL, mode redirects.MatchMode) bool {
-	if requested.Scheme != allowed.Scheme || requested.Host != allowed.Host {
+func urlEqualsSchemeHostPath(requested *url.URL, allowedHost, allowedPath string, mode redirects.MatchMode) bool {
+	requestedHost := (&url.URL{Scheme: requested.Scheme, Host: requested.Host}).String()
+	if requestedHost != allowedHost {
 		return false
 	}
 
 	switch mode {
 	case redirects.MatchModePrefix:
-		return strings.HasPrefix(requested.Path, allowed.Path)
+		return strings.HasPrefix(requested.Path, allowedPath)
 	case redirects.MatchModeStrict:
 		fallthrough
 	default:
-		return requested.Path == allowed.Path
+		return requested.Path == allowedPath
 	}
 }

--- a/Source/Pascal/logout/parser.go
+++ b/Source/Pascal/logout/parser.go
@@ -31,7 +31,12 @@ func (p *parser) ParseFrom(r *http.Request) (*Request, error) {
 		p.logger.Info("no token found in logout request")
 	}
 
-	returnTo, err := redirects.GetReturnToURL(p.configuration, p.configuration.DefaultLogoutReturnTo(), r, p.logger)
+	defaultReturnTo, err := redirects.GetAbsoluteUrlFor(r, p.configuration.DefaultLogoutReturnTo())
+	if err != nil {
+		return nil, err
+	}
+
+	returnTo, err := redirects.GetReturnToURL(p.configuration, defaultReturnTo, r, p.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/Source/Pascal/openid/authentication_initiator.go
+++ b/Source/Pascal/openid/authentication_initiator.go
@@ -13,7 +13,7 @@ import (
 type AuthenticationRedirectURL string
 
 type AuthenticationInitiator interface {
-	GetAuthenticationRedirect(nonce nonces.Nonce) (AuthenticationRedirectURL, error)
+	GetAuthenticationRedirect(host string, nonce nonces.Nonce) (AuthenticationRedirectURL, error)
 	GetLogoutRedirect(token *issuer.Token, returnTo sessions.ReturnToURL) (AuthenticationRedirectURL, error)
 }
 
@@ -31,12 +31,12 @@ type initiator struct {
 	watcher config.Watcher
 }
 
-func (i *initiator) GetAuthenticationRedirect(nonce nonces.Nonce) (AuthenticationRedirectURL, error) {
+func (i *initiator) GetAuthenticationRedirect(host string, nonce nonces.Nonce) (AuthenticationRedirectURL, error) {
 	issuer, err := i.watcher.GetIssuer()
 	if err != nil {
 		return "", err
 	}
-	redirect, err := issuer.GetAuthenticationRedirectURL(nonce)
+	redirect, err := issuer.GetAuthenticationRedirectURL(host, nonce)
 	if err != nil {
 		return "", err
 	}

--- a/Source/Pascal/openid/issuer/issuer.go
+++ b/Source/Pascal/openid/issuer/issuer.go
@@ -12,7 +12,7 @@ import (
 const idTokenKey = "id_token"
 
 type Issuer interface {
-	GetAuthenticationRedirectURL(nonce nonces.Nonce) (string, error)
+	GetAuthenticationRedirectURL(host string, nonce nonces.Nonce) (string, error)
 	ExchangeCodeForAccessToken(code string) (*Token, error)
 	ExchangeCodeForIDToken(code string) (*Token, error)
 	RevocationIsSupported() bool
@@ -67,8 +67,16 @@ func NewIssuer(issuerURL *url.URL, clientId, clientSecret string, scopes []strin
 	}, nil
 }
 
-func (i *issuer) GetAuthenticationRedirectURL(nonce nonces.Nonce) (string, error) {
-	return i.config.AuthCodeURL(string(nonce)), nil
+func (i *issuer) GetAuthenticationRedirectURL(host string, nonce nonces.Nonce) (string, error) {
+	redirectConfig := &oauth2.Config{
+		ClientID:     i.config.ClientID,
+		ClientSecret: i.config.ClientSecret,
+		Endpoint:     i.config.Endpoint,
+		Scopes:       i.config.Scopes,
+		RedirectURL:  host + i.config.RedirectURL,
+	}
+
+	return redirectConfig.AuthCodeURL(string(nonce)), nil
 }
 
 func (i *issuer) ExchangeCodeForAccessToken(code string) (*Token, error) {

--- a/Source/Pascal/redirects/configuration.go
+++ b/Source/Pascal/redirects/configuration.go
@@ -1,7 +1,5 @@
 package redirects
 
-import "net/url"
-
 type MatchMode int
 
 const (
@@ -11,8 +9,8 @@ const (
 
 type Configuration interface {
 	ReturnToParameter() string
-	DefaultLoginReturnTo() *url.URL
-	DefaultLogoutReturnTo() *url.URL
-	AllowedReturnTo() []*url.URL
+	DefaultLoginReturnTo() string
+	DefaultLogoutReturnTo() string
+	AllowedReturnTo() []string
 	ReturnToMatchMode() MatchMode
 }

--- a/Source/Pascal/redirects/getAbsoluteUrlFor.go
+++ b/Source/Pascal/redirects/getAbsoluteUrlFor.go
@@ -1,0 +1,31 @@
+package redirects
+
+import (
+	"net/http"
+	"net/url"
+)
+
+func GetHostFor(r *http.Request) string {
+	request := url.URL{
+		Scheme: "http",
+		Host:   r.Host,
+	}
+
+	if r.TLS != nil {
+		request.Scheme = "https"
+	}
+
+	for _, scheme := range r.Header.Values("x-forwarded-proto") {
+		request.Scheme = scheme
+	}
+
+	for _, host := range r.Header.Values("x-forwarded-host") {
+		request.Host = host
+	}
+
+	return request.String()
+}
+
+func GetAbsoluteUrlFor(r *http.Request, suffix string) (*url.URL, error) {
+	return url.Parse(GetHostFor(r) + suffix)
+}

--- a/Source/Pascal/server/configuration.go
+++ b/Source/Pascal/server/configuration.go
@@ -1,6 +1,8 @@
 package server
 
-import "dolittle.io/pascal/server/handling"
+import (
+	"dolittle.io/pascal/server/handling"
+)
 
 type Configuration interface {
 	Port() int

--- a/Source/Pascal/server/handling/configuration.go
+++ b/Source/Pascal/server/handling/configuration.go
@@ -1,7 +1,6 @@
 package handling
 
-import "net/url"
-
 type Configuration interface {
-	ErrorRedirect() *url.URL
+	AllowedHosts() []string
+	ErrorRedirect() string
 }

--- a/Source/Pascal/server/handling/router.go
+++ b/Source/Pascal/server/handling/router.go
@@ -1,9 +1,8 @@
 package handling
 
 import (
-	"net/http"
-
 	"go.uber.org/zap"
+	"net/http"
 )
 
 type Router interface {
@@ -13,26 +12,44 @@ type Router interface {
 
 func NewRouter(configuration Configuration, logger *zap.Logger) Router {
 	return &router{
-		configuration: configuration,
+		allowedHosts:  configuration.AllowedHosts(),
+		errorRedirect: configuration.ErrorRedirect(),
 		logger:        logger,
 		mux:           http.NewServeMux(),
 	}
 }
 
 type router struct {
-	configuration Configuration
+	allowedHosts  []string
+	errorRedirect string
 	logger        *zap.Logger
 	mux           *http.ServeMux
 }
 
 func (r *router) Handle(pattern string, handler Handler) {
 	r.mux.Handle(pattern, &wrappedHandler{
-		configuration: r.configuration,
+		errorRedirect: r.errorRedirect,
 		logger:        r.logger,
 		handler:       handler,
 	})
 }
 
 func (r *router) ServeHTTP(w http.ResponseWriter, re *http.Request) {
+	if !r.hostIsAllowed(re) {
+		r.logger.Warn("the requested host is not allowed", zap.String("host", re.Host))
+		http.NotFound(w, re)
+		return
+	}
+
 	r.mux.ServeHTTP(w, re)
+}
+
+func (r *router) hostIsAllowed(re *http.Request) bool {
+	for _, allowed := range r.allowedHosts {
+		if re.Host == allowed {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
## Summary

Adds support for running a single instance of Pascal to serve multiple hosts. The configuration now expects a list of allowed hostnames (`host[:port]`) that should be served (any other host is rejected with 404), and every other URL is constructed on the fly based on the host of the handled request. Every other URL in the configuration is now expected to be absolute relative to the current host.

Example config:
```
serve:
  port: 80

  hosts:
    - localhost:80

  paths:
    initiate: /initiate
    complete: /callback
    logout: /logout

urls:
  error: /error
  return:
    query_parameter: return_to
    default:
      login: /return
      logout: /return
    allowed:
      - /
    mode: strict

sessions:
  nonce_length: 80
  lifetime: 5m
  cookies:
    name: .dolittle.pascal.session
    secure: true
    samesite: lax
    path: /
  keys:
    - hash: KEY-USED-TO-SIGN-SESSION-COOKIES-SHOULD-BE-64-BYTES-LONG--------
      block: ENCRYPTION-KEY-SHOULD-BE-32-BYTS

openid:
  issuer: http://localhost:80
  client:
    id: client-id
    secret: client-secret
  scopes:
    - openid
  token_type: access_token
  redirect: /callback

cookies:
  name: .dolittle.pascal.login
  secure: true
  samesite: lax
  path: /
```


### Added

- [Pascal]: can handle requests for multiple hosts/domains.

### Changed

- [Pascal]: requires config of allowed hosts to serve, and redirect URLs now need to be just absolute paths without a host.
- [Pascal]: skip logging stack trace at warning log messages.

### Fixed

- [Login/Web]: upgrade `rest-hooks` packages so that the build un-breaks.